### PR TITLE
Add theme inspired by Nord

### DIFF
--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -3,3 +3,4 @@ export * from "./tailwindcss";
 export * from "./vue";
 export * from "./lavender";
 export * from "./linear";
+export * from "./nord";

--- a/src/themes/nord.ts
+++ b/src/themes/nord.ts
@@ -1,0 +1,25 @@
+import { Theme } from "~/composables/theme-utils";
+
+export const nord: Theme = {
+  key: "nord",
+  name: "Nord",
+  inspiration: "Nord Theme",
+  inspirationUrl: "https://www.nordtheme.com/",
+  shadow: "hsl(220, 17%, 17%)",
+  background: `linear-gradient(
+    140deg,
+	hsl(220, 16%, 36%),
+	hsl(220, 17%, 32%),
+	hsl(222, 16%, 28%),
+	hsl(220, 16%, 22%)
+  )`,
+  monaco: {
+    foreground: "hsl(218, 27%, 94%)",
+    comments: "hsl(220, 16%, 36%)",
+    keywords: "hsl(213, 32%, 52%)",
+    delimiters: "hsl(219, 28%, 88%)",
+    strings: "hsl(92, 28%, 65%)",
+    numbers: "hsl(311, 20%, 63%)",
+    regexp: "hsl(14, 51%, 63%)",
+  },
+};


### PR DESCRIPTION
# Add new Nord theme

As requested here #10, I added this new theme inspired by [Nord](https://www.nordtheme.com/)

## Result
![nord_theme](https://user-images.githubusercontent.com/2037375/166837773-6fd54024-4c40-478f-9a0a-36e177191f1b.png)

## Pallettes
![nord_pallettes](https://user-images.githubusercontent.com/2037375/166837741-c1285c48-729a-42ab-8772-8accfce32e2d.png)

The shadow color was extracted from their website. It is the darkest black:
- #242933

The four gradient background colors are the Polar Night:
- #2E3440
- #3B4252
- #434C5E
- #4C566A

Foreground and delimiters are the lightest and darkest Snow Storm, respectively:
- #ECEFF4
- #D8DEE9

Comments are lightest Polar Night:
- #4C566A

Keywords are blue:
- #81A1C1

Strings are green:
- #A3BE8C

Nmbers are violet:
- #B48EAD

Regex are orange:
- #D08770