### PR TITLE
fix(editor): remove outline when editor has focus

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -165,7 +165,7 @@ const fontFamily = computed(() => {
     />
 
     <textarea
-      class="editor"
+      class="editor focus-visible:outline-none"
       ref="editor"
       v-model="block.content"
       spellcheck="false"


### PR DESCRIPTION
This pull request removes the default browser outline when there is focus inside the editor.

### Before

![CleanShot 2023-12-23 at 01 39 49](https://github.com/Idered/chalk.ist/assets/16060559/61ab91e0-44ca-4036-b0f3-ccfd07ee2e39)

### After

![CleanShot 2023-12-23 at 01 41 55](https://github.com/Idered/chalk.ist/assets/16060559/8dbcff46-9014-493c-850b-378bed4be4b9)
