### PR TITLE
Disable grammarly from text editor

### DIFF
--- a/src/components/TheEditor.vue
+++ b/src/components/TheEditor.vue
@@ -394,6 +394,7 @@ const charactersPerLine = computed(() =>
       ref="editor"
       v-model="block.content"
       spellcheck="false"
+      data-enable-grammarly="false"
       :class="{
         'pointer-events-none': store.editMode !== 'code',
       }"


### PR DESCRIPTION
Adds `data-enable-grammarly` to the text editor to avoid rendering the grammarly extension, which also gets contained when downloading/copying the code snippets. 

Example with grammarly extension:

![CleanShot 2024-03-02 at 10 57 24](https://github.com/Idered/chalk.ist/assets/48022589/b6f64061-7845-4916-b84e-3932b874cad3)
