### PR TITLE
fix: remove scrollbars in editor when using large font sizes

### DIFF
--- a/app/components/ui/editor/Editor.client.vue
+++ b/app/components/ui/editor/Editor.client.vue
@@ -471,6 +471,7 @@ const innerPaddingX = computed(() => `${store.value.innerPaddingX}px`);
   caret-color: white;
   outline: none;
   white-space: pre-wrap;
+  overflow: hidden;
 }
 
 .formatted {


### PR DESCRIPTION
fixes #72 